### PR TITLE
fix(android): return 1 for requestPermission

### DIFF
--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -276,9 +276,24 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
 
   public requestPermission(
     permissions: IOSNotificationPermissions = {},
-  ): Promise<IOSNotificationSettings | 1> {
+  ): Promise<IOSNotificationSettings> {
     if (isAndroid) {
-      return Promise.resolve(1);
+      // Android doesn't require permission, so instead we
+      // return a dummy response to allow the permissions
+      // flow work the same on both iOS & Android
+      return Promise.resolve({
+        alert: 1,
+        badge: 1,
+        criticalAlert: 1,
+        showPreviews: 1,
+        sound: 1,
+        carPlay: 1,
+        lockScreen: 1,
+        announcement: 1,
+        notificationCenter: 1,
+        inAppNotificationSettings: 1,
+        authorizationStatus: 1,
+      } as IOSNotificationSettings);
     }
 
     let options: IOSNotificationPermissions;

--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -276,9 +276,9 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
 
   public requestPermission(
     permissions: IOSNotificationPermissions = {},
-  ): Promise<IOSNotificationSettings | null> {
+  ): Promise<IOSNotificationSettings | 1> {
     if (isAndroid) {
-      return Promise.resolve(null);
+      return Promise.resolve(1);
     }
 
     let options: IOSNotificationPermissions;

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -306,14 +306,33 @@ export interface Module {
   /**
    * Request specific notification permissions for your application on the current device.
    *
-   * Returns 1 (UNAuthorizationStatus.UNAuthorizationStatusAuthorized Enum = 1 for iOS) on Android.
+   * Both iOS & Android return an `IOSNotificationSettings` interface. To check whether overall
+   * permission was granted, check the `authorizationStatus` property in the response:
    *
-   *   TODO better description
+   * ```js
+   * import notifee, { IOSAuthorizationStatus } from '@notifee/react-native';
+   *
+   * const settings = await notifee.requestPermission(...);
+   *
+   * if (settings.authorizationStatus === IOSAuthorizationStatus.DENIED) {
+   *   console.log('User denied permissions request');
+   * } else if (settings.authorizationStatus === IOSAuthorizationStatus.AUTHORIZED) {
+   *    console.log('User granted permissions request');
+   * } else if (settings.authorizationStatus === IOSAuthorizationStatus.PROVISIONAL) {
+   *    console.log('User provisionally granted permissions request');
+   * }
+   * ```
+   *
+   * Use the other `IOSNotificationSettings` properties to view which specific permissions were
+   * allowed.
+   *
+   * On Android, all of the properties on the `IOSNotificationSettings` interface response return
+   * as `AUTHORIZED`.
    *
    * @platform ios
    * @param permissions
    */
-  requestPermission(permissions?: IOSNotificationPermissions): Promise<IOSNotificationSettings | 1>;
+  requestPermission(permissions?: IOSNotificationPermissions): Promise<IOSNotificationSettings>;
 
   /**
    * Set the notification categories to be used on this Apple device.
@@ -483,4 +502,5 @@ export interface ModuleStatics {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ModuleWithStatics extends Module, ModuleStatics {}
+export interface ModuleWithStatics extends Module, ModuleStatics {
+}

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -306,16 +306,14 @@ export interface Module {
   /**
    * Request specific notification permissions for your application on the current device.
    *
-   * Returns null on Android.
+   * Returns 1 (UNAuthorizationStatus.UNAuthorizationStatusAuthorized Enum = 1 for iOS) on Android.
    *
    *   TODO better description
    *
    * @platform ios
    * @param permissions
    */
-  requestPermission(
-    permissions?: IOSNotificationPermissions,
-  ): Promise<IOSNotificationSettings | null>;
+  requestPermission(permissions?: IOSNotificationPermissions): Promise<IOSNotificationSettings | 1>;
 
   /**
    * Set the notification categories to be used on this Apple device.


### PR DESCRIPTION
fixes #60.

As per [RNFB](https://github.com/invertase/react-native-firebase/blob/1d7cd28f85d09d35805b59896809ca93aa436285/packages/messaging/lib/index.js#L212), return `1` for `requestPermission` method to let user know they've consented to receive notifications via the app.