### PR TITLE
Add skipLibCheck: true to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "strict": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules"],
   "include": ["./src"]


### PR DESCRIPTION
It may be reasonably argued that this should be false and libs
should be checked, but I encounter a large batch of non-notifiee-related
errors when I attempt to run tsc with skipLibCheck: true

Because I understand there are good arguments to leave it on I will not be
offended at all if you disagree and close this