### PR TITLE
fixed foreground service task registration

### DIFF
--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -29,7 +29,7 @@ let onNotificationEventHeadlessTaskRegistered = false;
 let registeredForegroundServiceTask: (notification: Notification) => Promise<void>;
 
 if (isAndroid) {
-  AppRegistry.registerHeadlessTask('app.notifee.notification.event', () => {
+  AppRegistry.registerHeadlessTask('app.notifee.foreground.task', () => {
     if (!registeredForegroundServiceTask) {
       console.warn(
         '[notifee] no registered foreground service has been set for displaying a foreground notification.',


### PR DESCRIPTION
Task key was wrong, it should be "app.notifee.foreground.task" instead of "app.notifee.notification.event"
This will remove warning "registerHeadlessTask called multiple times for same key" when using notifee.onBackgroundEvent and fix usage of foreground service task.