### PR TITLE
Use version of OkHTTP that works on Android 4.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,7 +65,10 @@ dependencies {
   } else {
     implementation fileTree(include: ['notifee_core_release.aar'], dir: 'libs')
   }
-  implementation(platform("com.squareup.okhttp3:okhttp-bom:4.4.1"))
+
+  // OkHTTP may be updated to most recent version if minSdkVersion >= 20
+  //noinspection GradleDependency NewerVersionAvailable
+  implementation 'com.squareup.okhttp3:okhttp:3.12.12'
   implementation 'androidx.concurrent:concurrent-futures:1.0.0'
   implementation 'com.google.android.gms:play-services-tasks:17.1.0'
   implementation 'androidx.work:work-runtime:2.3.4'


### PR DESCRIPTION
Fixes #95

Note that on lower platforms (I tested on API19 real device) remote verification can fail for TLS1.2 reasons.

If you get fancy and install an SSL provider in MainApplication::onCreate early, you can guarantee that you have TLS1.2 available:

`android/app/src/main/java/..../MainApplication.java` snippet:

```java
import com.google.android.gms.security.ProviderInstaller;

  public void onCreate() {
    Log.d("ReactNativeJS", "MainApplication::onCreate - starting up application");

    Log.d("ReactNativeJS", "Patching SSL Provider before anything...");
    try {
      if (Build.VERSION.SDK_INT <= 20) {
        ProviderInstaller.installIfNeeded(this);
      }
    } catch (Throwable t) {
      Log.w("ReactNativeJS", "Unable to install SSL provider", t);
    }

    super.onCreate();
    SoLoader.init(this, /* native exopackage */ false);
  
    ....
```

However, when this is done, there is still some sort of problem with remote verification (but not a TLS handshake - which happens without the provider install), whereas it works on higher APIs?

```

06-30 22:16:48.004 25898-25898/com.kullki.kscore.dev E/License: java.security.spec.InvalidKeySpecException: com.google.android.gms.org.conscrypt.OpenSSLX509CertificateFactory$ParsingException: Error parsing private key
        at com.google.android.gms.org.conscrypt.OpenSSLKey.getPrivateKey(:com.google.android.gms@202117000@20.21.17 (000300-316502805):2)
        at com.google.android.gms.org.conscrypt.OpenSSLRSAKeyFactory.engineGeneratePrivate(:com.google.android.gms@202117000@20.21.17 (000300-316502805):2)
        at java.security.KeyFactory.generatePrivate(KeyFactory.java:186)
        at n.o.t.i.f.e.e.nZ_i.nz_n(SourceFile:132)
        at app.notifee.core.Worker.nz_n(SourceFile:27)
        at app.notifee.core.Worker.lambda$6bc3g2OwlMH0Cmb2IhUkkKcXUN0(SourceFile)
        at app.notifee.core.-$$Lambda$Worker$6bc3g2OwlMH0Cmb2IhUkkKcXUN0.attachCompleter(lambda)
        at androidx.concurrent.futures.CallbackToFutureAdapter.getFuture(CallbackToFutureAdapter.java:102)
        at app.notifee.core.Worker.startWork(SourceFile:1)
```

It may be that remote verification is not easily possible on API<=20 ?
