### PR TITLE
fix(react-native):  app project is evaluated first

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,8 @@ plugins {
   id "io.invertase.gradle.build" version "1.3"
 }
 
+project.evaluationDependsOn(':app')
+
 project.ext {
   set('react-native', [
     versions: [


### PR DESCRIPTION
fixes #88
 
When building for RN `0.60.0`, I noticed that the tasks for `@notifee_react-native` were preceding the tasks for `app` project (as noted in the screenshot) which is probably why `android` property is `null`.  The android gradle plugin hasn't been applied yet (I think). 
![Screenshot 2020-07-03 at 12 07 22](https://user-images.githubusercontent.com/16018629/86465275-3ba1f500-bd29-11ea-8aa4-08406a1ca116.png)


This PR ensures the `@notifee_react-native` project is dependent on the `app` project.

I've tested on RN version `0.60` & latest. Building successfully and notifications working.