### PR TITLE
delay sending events on ios

### DIFF
--- a/ios/RNNotifee/NotifeeApiModule.m
+++ b/ios/RNNotifee/NotifeeApiModule.m
@@ -77,7 +77,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)sendNotifeeCoreEvent:(NSDictionary *_Nonnull)eventBody {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (RCTRunningInAppExtension() || [UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
             [self sendEventWithName:kReactNativeNotifeeNotificationBackgroundEvent body:eventBody];
         } else {

--- a/ios/RNNotifee/NotifeeApiModule.m
+++ b/ios/RNNotifee/NotifeeApiModule.m
@@ -77,7 +77,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)sendNotifeeCoreEvent:(NSDictionary *_Nonnull)eventBody {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (RCTRunningInAppExtension() || [UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
             [self sendEventWithName:kReactNativeNotifeeNotificationBackgroundEvent body:eventBody];
         } else {


### PR DESCRIPTION
Put in a delay of 1 second around sending foreground + background events for iOS.
Maybe can exclude for certain foreground events for example, TRIGGER_NOTIFICATION_CREATED. 