### PR TITLE
fix(android, build): Build.VERSION_NAME removed in gradle plugin 4.1

### DIFF
--- a/android/src/main/java/io/invertase/notifee/NotifeeInitProvider.java
+++ b/android/src/main/java/io/invertase/notifee/NotifeeInitProvider.java
@@ -4,6 +4,10 @@
 
 package io.invertase.notifee;
 
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
 import app.notifee.core.InitProvider;
 import app.notifee.core.Notifee;
 import app.notifee.core.NotifeeConfig;
@@ -16,12 +20,28 @@ public class NotifeeInitProvider extends InitProvider {
     boolean onCreate = super.onCreate();
 
     NotifeeConfig.Builder configBuilder = new NotifeeConfig.Builder();
-    configBuilder.setProductVersion(BuildConfig.VERSION_NAME);
+    configBuilder.setProductVersion(getApplicationVersionString());
     configBuilder.setFrameworkVersion(getReactNativeVersionString());
     configBuilder.setEventSubscriber(new NotifeeEventSubscriber());
 
     Notifee.configure(configBuilder.build());
     return onCreate;
+  }
+
+  private String getApplicationVersionString() {
+    String version = "unknown";
+    Context context = this.getContext();
+    if (context != null) {
+      PackageManager pm = context.getPackageManager();
+      try {
+        PackageInfo pInfo = pm.getPackageInfo(context.getPackageName(), 0);
+        version = pInfo.versionName;
+      } catch (Exception e) {
+        // is there anything useful to log the unbelievably unexpected inability to get package info?
+      }
+    }
+
+    return version;
   }
 
   private String getReactNativeVersionString() {


### PR DESCRIPTION
The gradle plugin team made some breaking changes between version 4.0 and 4.1, namely they removed propagation of Build.VERSION_NAME for libraries and encourage dynamic resolution of the same

https://issuetracker.google.com/issues/158695880#comment7

This breaks the build for anyone using Notifee and Android Gradle Plugin 4.0.1 (currently at rc02, so will likely release soon)

Noticed by @AndrewMorsillo (thanks!)

Fixes #143

patch-package format patch for affected customers to use prior to versioned release here, available on related issue: https://github.com/notifee/react-native-notifee/issues/143#issuecomment-687823683