### PR TITLE
fix(ios, podspec): depend directly on React-Core, not React

### DIFF
--- a/RNNotifee.podspec
+++ b/RNNotifee.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target   = '10.0'
   s.source_files             = 'ios/RNNotifee/*.{h,m}'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
   if defined?($NotifeeCoreFromSources) && $NotifeeCoreFromSources == true
     # internal dev flag used by Notifee devs, ignore


### PR DESCRIPTION
This is apparently the correct way to do it, as React-Core has the APIs native iOS modules actually need,
and they were only pulled in transitively by React, but in Xcode 12 something about the build system is racy
and leads to compile failures sometimes if this isn't direct.

CF https://github.com/facebook/react-native/issues/29633