### PR TITLE
feat(android): background restrictions helper api

### DIFF
--- a/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -187,6 +187,20 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule {
             (e, aVoid) -> NotifeeReactUtils.promiseResolver(promise, e));
   }
 
+  @ReactMethod
+  public void openBatteryOptimizationSettings(Promise promise) {
+    Notifee.getInstance()
+        .openBatteryOptimizationSettings(
+            getCurrentActivity(), (e, aVoid) -> NotifeeReactUtils.promiseResolver(promise, e));
+  }
+
+  @ReactMethod
+  public void isBatteryOptimizationEnabled(Promise promise) {
+    Notifee.getInstance()
+        .isBatteryOptimizationEnabled(
+            (e, aBundle) -> NotifeeReactUtils.promiseResolver(promise, e, aBundle));
+  }
+
   @NonNull
   @Override
   public String getName() {

--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -483,4 +483,19 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
 
     return this.native.decrementBadgeCount(Math.round(value));
   }
+
+  public isBatteryOptimizationEnabled(): Promise<boolean> {
+    if (isIOS) {
+      return Promise.resolve(false);
+    }
+
+    return this.native.isBatteryOptimizationEnabled();
+  }
+
+  public openBatteryOptimizationSettings(): Promise<void> {
+    if (isIOS) {
+      return Promise.resolve();
+    }
+    return this.native.openBatteryOptimizationSettings();
+  }
 }

--- a/src/types/Module.ts
+++ b/src/types/Module.ts
@@ -190,9 +190,6 @@ export interface Module {
    *
    * View the [Triggers](/react-native/docs/triggers) documentation for more information.
    *
-   * Currently only supported on Android.
-   *
-   * @platform android
    */
   getTriggerNotificationIds(): Promise<string[]>;
 
@@ -451,6 +448,25 @@ export interface Module {
    * @platform ios
    */
   decrementBadgeCount(decrementBy?: number): Promise<void>;
+
+  /**
+   * API used to open the Android System settings for the application.
+   *
+   * If the API version is >= 23, the battery optimization settings screen is displayed, otherwise,
+   * this is a no-op & instantly resolves.
+   *
+   * @platform android
+   */
+  openBatteryOptimizationSettings(): Promise<void>;
+
+  /**
+   * API used to check if battery optimization is enabled for your application.
+   *
+   * Supports API versions >= 23.
+   *
+   * @platform android
+   */
+  isBatteryOptimizationEnabled(): Promise<boolean>;
 }
 
 /**


### PR DESCRIPTION
Fixes #126. 

API to help prevent the device from killing your app while it's in the background:
`isBatteryOptimizationEnabled()`
 `openBatteryOptimizationSettings()`

Example:
```
// 1. checks if battery optimization is enabled
const batteryOptimizationEnabled = await notifee.isBatteryOptimizationEnabled();
if (batteryOptimizationEnabled) {
  // 2. ask your users to disable the feature
  Alert.alert(
      'Restrictions Detected',
      'To ensure notifications are delivered, please disable battery optimization for the app.',
      [
        // 3. launch intent to navigate the user to the appropriate screen
        {
          text: 'OK, open settings',
          onPress: async () => await notifee.openBatteryOptimizationSettings(),
        },
        {
          text: "Cancel",
          onPress: () => console.log("Cancel Pressed"),
          style: "cancel"
        },
      ],
      { cancelable: false }
    );
};
```