### PR TITLE
feat(*): timestamp trigger update to accept a repeatFrequency property

### DIFF
--- a/src/types/Trigger.ts
+++ b/src/types/Trigger.ts
@@ -12,6 +12,28 @@ export interface TimestampTrigger {
    * The timestamp when the notification should first be shown, in milliseconds since 1970.
    */
   timestamp: number;
+
+  /**
+   * The frequency at which the trigger repeats.
+   * If unset, the notification will only be displayed once.
+   *
+   * For example:
+   *  if set to `Frequency.HOURLY`, the notification will repeat every hour from the timestamp specified.
+   *  if set to `Frequency.DAILY`, the notification will repeat every day from the timestamp specified.
+   *  if set to `Frequency.WEEKLY`, the notification will repeat every week from the timestamp specified.
+   */
+  repeatFrequency?: RepeatFrequency | RepeatFrequency.DAILY;
+}
+
+/**
+ * An interface representing the different frequencies which can be used with `TimestampTrigger.repeatFrequency`.
+ *
+ * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ */
+export enum RepeatFrequency {
+  HOURLY = 0,
+  DAILY = 1,
+  WEEKLY = 2,
 }
 
 /**

--- a/src/types/Trigger.ts
+++ b/src/types/Trigger.ts
@@ -18,11 +18,11 @@ export interface TimestampTrigger {
    * If unset, the notification will only be displayed once.
    *
    * For example:
-   *  if set to `Frequency.HOURLY`, the notification will repeat every hour from the timestamp specified.
-   *  if set to `Frequency.DAILY`, the notification will repeat every day from the timestamp specified.
-   *  if set to `Frequency.WEEKLY`, the notification will repeat every week from the timestamp specified.
+   *  if set to `RepeatFrequency.HOURLY`, the notification will repeat every hour from the timestamp specified.
+   *  if set to `RepeatFrequency.DAILY`, the notification will repeat every day from the timestamp specified.
+   *  if set to `RepeatFrequency.WEEKLY`, the notification will repeat every week from the timestamp specified.
    */
-  repeatFrequency?: RepeatFrequency | RepeatFrequency.DAILY;
+  repeatFrequency?: RepeatFrequency;
 }
 
 /**

--- a/src/validators/validateTrigger.ts
+++ b/src/validators/validateTrigger.ts
@@ -6,6 +6,7 @@ import { objectHasProperty, isNumber, isObject, isValidEnum } from '../utils';
 import {
   Trigger,
   TimeUnit,
+  RepeatFrequency,
   TimestampTrigger,
   IntervalTrigger,
   TriggerType,
@@ -52,10 +53,20 @@ function validateTimestampTrigger(trigger: TimestampTrigger): TimestampTrigger {
     throw new Error("'trigger.timestamp' date must be in the future.");
   }
 
-  return {
+  const out: TimestampTrigger = {
     type: trigger.type,
     timestamp: trigger.timestamp,
+    repeatFrequency: -1,
   };
+
+  if (objectHasProperty(trigger, 'repeatFrequency')) {
+    if (!isValidEnum(trigger.repeatFrequency, RepeatFrequency)) {
+      throw new Error("'trigger.repeatFrequency' expected a RepeatFrequency value.");
+    }
+    out.repeatFrequency = trigger.repeatFrequency;
+  }
+
+  return out;
 }
 
 function validateIntervalTrigger(trigger: IntervalTrigger): IntervalTrigger {


### PR DESCRIPTION
Fixes #140 To allow timestamp trigger to occur HOURLY, DAILY, or WEEKLY. 

Example:

```
    Date date = Date.now();
    date.setHours(11);
    date.setMinutes(10);

    const trigger: TimestampTrigger = {
      type: TriggerType.TIMESTAMP,
      timestamp: date.getTime(),
      repeatFrequency: RepeatFrequency.WEEKLY
    };

  await notifee.createTriggerNotification(
    {
      id: '123',
      title: 'Meeting with Jane',
      body: 'Today at 11:20am',
      android: {
        channelId: 'your-channel-id',
      },
    },
    trigger,
  );
```