### PR TITLE
fix(android): fix to prevent warning 'No task registered'

### DIFF
--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -38,9 +38,11 @@ import {
 import validateIOSCategory from './validators/validateIOSCategory';
 import validateIOSPermissions from './validators/validateIOSPermissions';
 
+let backgroundEventHandler: (event: Event) => Promise<void>;
+
 let isRunningForegroundServiceTask = false;
-let backgroundMessageHandler: (event: Event) => Promise<void>;
 let registeredForegroundServiceTask: (notification: Notification) => Promise<void>;
+
 if (isAndroid) {
   // Register foreground service
   AppRegistry.registerHeadlessTask(kReactNativeNotifeeForegroundServiceHeadlessTask, () => {
@@ -62,29 +64,29 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
       // Register background handler
       AppRegistry.registerHeadlessTask(kReactNativeNotifeeNotificationEvent, () => {
         return (event: Event): Promise<void> => {
-          if (!backgroundMessageHandler) {
+          if (!backgroundEventHandler) {
             // eslint-disable-next-line no-console
             console.warn(
-              '[notifee] no background message handler has been set. Set a handler via the "onBackgroundEvent" method.',
+              '[notifee] no background event handler has been set. Set a handler via the "onBackgroundEvent" method.',
             );
             return Promise.resolve();
           }
-          return backgroundMessageHandler(event);
+          return backgroundEventHandler(event);
         };
       });
     } else if (isIOS) {
       this.emitter.addListener(
         kReactNativeNotifeeNotificationBackgroundEvent,
         (event: Event): Promise<void> => {
-          if (!backgroundMessageHandler) {
+          if (!backgroundEventHandler) {
             // eslint-disable-next-line no-console
             console.warn(
-              '[notifee] no background message handler has been set. Set a handler via the "onBackgroundEvent" method.',
+              '[notifee] no background event handler has been set. Set a handler via the "onBackgroundEvent" method.',
             );
             return Promise.resolve();
           }
 
-          return backgroundMessageHandler(event);
+          return backgroundEventHandler(event);
         },
       );
     }
@@ -325,7 +327,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
       throw new Error("notifee.onBackgroundEvent(*) 'observer' expected a function.");
     }
 
-    backgroundMessageHandler = observer;
+    backgroundEventHandler = observer;
   }
 
   public onForegroundEvent(observer: (event: Event) => void): () => void {

--- a/src/NotifeeApiModule.ts
+++ b/src/NotifeeApiModule.ts
@@ -13,7 +13,7 @@ import {
 import { InitialNotification, Notification, Event } from './types/Notification';
 import { PowerManagerInfo } from './types/PowerManagerInfo';
 import { Trigger } from './types/trigger';
-import NotifeeNativeModule from './NotifeeNativeModule';
+import NotifeeNativeModule, { NativeModuleConfig } from './NotifeeNativeModule';
 import {
   isAndroid,
   isArray,
@@ -38,11 +38,11 @@ import {
 import validateIOSCategory from './validators/validateIOSCategory';
 import validateIOSPermissions from './validators/validateIOSPermissions';
 
-let onNotificationBackgroundEventListenerRegistered = false;
 let isRunningForegroundServiceTask = false;
+let backgroundMessageHandler: (event: Event) => Promise<void>;
 let registeredForegroundServiceTask: (notification: Notification) => Promise<void>;
-
 if (isAndroid) {
+  // Register foreground service
   AppRegistry.registerHeadlessTask(kReactNativeNotifeeForegroundServiceHeadlessTask, () => {
     if (!registeredForegroundServiceTask) {
       console.warn(
@@ -56,6 +56,40 @@ if (isAndroid) {
 }
 
 export default class NotifeeApiModule extends NotifeeNativeModule implements Module {
+  constructor(config: NativeModuleConfig) {
+    super(config);
+    if (isAndroid) {
+      // Register background handler
+      AppRegistry.registerHeadlessTask(kReactNativeNotifeeNotificationEvent, () => {
+        return (event: Event): Promise<void> => {
+          if (!backgroundMessageHandler) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              '[notifee] no background message handler has been set. Set a handler via the "onBackgroundEvent" method.',
+            );
+            return Promise.resolve();
+          }
+          return backgroundMessageHandler(event);
+        };
+      });
+    } else if (isIOS) {
+      this.emitter.addListener(
+        kReactNativeNotifeeNotificationBackgroundEvent,
+        (event: Event): Promise<void> => {
+          if (!backgroundMessageHandler) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              '[notifee] no background message handler has been set. Set a handler via the "onBackgroundEvent" method.',
+            );
+            return Promise.resolve();
+          }
+
+          return backgroundMessageHandler(event);
+        },
+      );
+    }
+  }
+
   public getTriggerNotificationIds(): Promise<string[]> {
     return this.native.getTriggerNotificationIds();
   }
@@ -291,27 +325,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
       throw new Error("notifee.onBackgroundEvent(*) 'observer' expected a function.");
     }
 
-    if (
-      isAndroid &&
-      (isRunningForegroundServiceTask || !onNotificationBackgroundEventListenerRegistered)
-    ) {
-      AppRegistry.registerHeadlessTask(kReactNativeNotifeeNotificationEvent, () => {
-        return ({ type, detail }): Promise<void> => {
-          return observer({ type, detail });
-        };
-      });
-      onNotificationBackgroundEventListenerRegistered = true;
-    }
-
-    if (isIOS && !onNotificationBackgroundEventListenerRegistered) {
-      this.emitter.addListener(
-        kReactNativeNotifeeNotificationBackgroundEvent,
-        ({ type, detail }) => {
-          observer({ type, detail });
-        },
-      );
-      onNotificationBackgroundEventListenerRegistered = true;
-    }
+    backgroundMessageHandler = observer;
   }
 
   public onForegroundEvent(observer: (event: Event) => void): () => void {
@@ -516,7 +530,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
     return this.native.openBatteryOptimizationSettings();
   }
 
-   public getPowerManagerInfo(): Promise<PowerManagerInfo> {
+  public getPowerManagerInfo(): Promise<PowerManagerInfo> {
 
     if (isIOS) {
       // iOS doesn't support this, so instead we


### PR DESCRIPTION
Updated how background message handler is registered to prevent  React Native logging a warning when `onBackgroundEvent` isn't set.

Instead of React Native logging a warning:
`W/ReactNativeJS: No task registered for key app.notifee.notification-event`

A more descriptive warning will be logged by Notifee, and a fallback background message handler will be used instead:
`[notifee] no background message handler has been set. Set a handler via the "onBackgroundEvent" method.`

Addresses #111. 