### PR TITLE
fix(ios): declaratively enforce v1.10+ of cocoapods

### DIFF
--- a/RNNotifee.podspec
+++ b/RNNotifee.podspec
@@ -14,7 +14,8 @@ Pod::Spec.new do |s|
   s.source              = { :git => "https://github.com/notifee/react-native-notifee", :tag => "v#{s.version}" }
   s.social_media_url    = 'http://twitter.com/notifee_app'
 
-  s.ios.deployment_target   = '10.0'
+  s.cocoapods_version        = '>= 1.10.0'
+  s.ios.deployment_target    = '10.0'
   s.source_files             = 'ios/RNNotifee/*.{h,m}'
   s.dependency 'React-Core'
 


### PR DESCRIPTION
We definitely require cocoapods v1.10+ now that we use .xcframework to distribute
the library, but previously had not enforced it anywhere.

Fixes #230

This was taken from https://github.com/invertase/firestore-ios-sdk-frameworks/pull/22/files which has been released to public for a month now so it should work fine