### PR TITLE
Update android import format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ The APIs for Android allow for creating rich, styled and highly interactive noti
 | [Styles](https://notifee.app/react-native/docs/android/styles)                           | Style notifications to show richer content, such as expandable images/text, or message conversations.                             |
 | [Timers](https://notifee.app/react-native/docs/android/timers)                           | Display counting timers on your notification, useful for on-going tasks such as a phone call, or event time remaining.            |
 
+#### Import
+
+This library requires the import of the core library, because of that you need to add the following import to your root `build.gradle`:
+
+```
+allprojects {
+    repositories {
+        ....
+        flatDir {
+            dirs "$rootDir/../node_modules/@notifee/react-native/android/libs"
+        }
+    }
+}
+```
+
 ### iOS
 
 Below you'll find guides that cover the supported iOS features.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   if (findProject(':notifee_core')) {
     implementation findProject(':notifee_core')
   } else {
-    implementation fileTree(include: ['notifee_core_release.aar'], dir: 'libs')
+    compile(name: 'notifee_core_release', ext: 'aar')
   }
   implementation 'androidx.concurrent:concurrent-futures:1.0.0'
   implementation 'com.google.android.gms:play-services-tasks:17.1.0'


### PR DESCRIPTION
This library requires a local import of an `aar` and because of that it 's required to add the import of the core `aar` to the project that it's using the library otherwise it will be necessary to use different commands to build the app. 

Closes: https://github.com/notifee/documentation/issues/8

Refs: https://github.com/notifee/react-native-notifee/issues/151

This is the same approach used by https://github.com/react-native-community/jsc-android-buildscripts#readme, https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md etc...

**A better improvement would be upload the `aar` file to the [maven repository](https://mvnrepository.com/) and put it as a dependency of this library.**