### PR TITLE
fix(android, build): do not create duplicate target variant tasks

### DIFF
--- a/android/notifee-json.gradle
+++ b/android/notifee-json.gradle
@@ -187,11 +187,19 @@ class NotifeeJsonTask extends DefaultTask {
 def registerJsonTaskForProjectVariant(jsonFile, targetProject, targetVariant) {
   File outputDir = targetProject.file("$targetProject.buildDir/generated/res/notifee/$targetVariant.dirName")
 
-  NotifeeJsonTask task = targetProject.tasks.create("process${targetVariant.name.capitalize()}NotifeeJson", NotifeeJsonTask)
+  String variantTaskName = "process${targetVariant.name.capitalize()}NotifeeJson";
+  String buildTypeName = targetVariant.getBuildType().name;
+  String buildFlavorName = targetVariant.flavorName ? targetVariant.flavorName : "";
 
-  task.setBuildType(targetVariant.getBuildType().name)
+  NotifeeJsonTask task = targetProject.tasks.findByName(variantTaskName);
 
-  task.setBuildFlavor(targetVariant.flavorName ? targetVariant.flavorName : "")
+  if(!task) {
+    task = targetProject.tasks.create(variantTaskName, NotifeeJsonTask)
+  }
+
+  task.setBuildType(buildTypeName)
+
+  task.setBuildFlavor(buildFlavorName)
 
   task.setOutputDirectory(outputDir)
 

--- a/android/notifee-json.gradle
+++ b/android/notifee-json.gradle
@@ -193,7 +193,7 @@ def registerJsonTaskForProjectVariant(jsonFile, targetProject, targetVariant) {
 
   NotifeeJsonTask task = targetProject.tasks.findByName(variantTaskName);
 
-  if(!task) {
+  if (!task) {
     task = targetProject.tasks.create(variantTaskName, NotifeeJsonTask)
   }
 


### PR DESCRIPTION
Hello,

We in @Breadfast have an issue that makes us unable to build android so I have written a fix for it.

You can find the issue repeated in these issues:  #122 & #269 

Hope you find this fix helpful.

Thanks
