### PR TITLE
fix(android, jwt): repair jwt gradle build dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,10 +76,10 @@ dependencies {
   // https://github.com/square/okhttp/blob/master/docs/changelog_3x.md
   implementation 'com.squareup.okhttp3:okhttp:3.12.12' // okhttp must stay on 3.12.x to support minSdkVersion < 21
 
-  def jwt_version = '0.11.2' // https://github.com/jwtk/jjwt/releases
-  api 'io.jsonwebtoken:jjwt-api:$jwt_version'
-  runtimeOnly 'io.jsonwebtoken:jjwt-impl:$jwt_version' 
-  runtimeOnly('io.jsonwebtoken:jjwt-orgjson:$jwt_version') {
+  // https://github.com/jwtk/jjwt/releases
+  api 'io.jsonwebtoken:jjwt-api:0.11.2'
+  runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+  runtimeOnly('io.jsonwebtoken:jjwt-orgjson:0.11.2') {
     exclude group: 'org.json', module: 'json' //provided by Android natively
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,10 +76,11 @@ dependencies {
   // https://github.com/square/okhttp/blob/master/docs/changelog_3x.md
   implementation 'com.squareup.okhttp3:okhttp:3.12.12' // okhttp must stay on 3.12.x to support minSdkVersion < 21
 
-def jwt_version = '0.11.2' // https://github.com/jwtk/jjwt/releases
-  api "io.jsonwebtoken:jjwt-api:$jwt_version"
-  runtimeOnly("io.jsonwebtoken:jjwt-api:$jwt_version") {
-    exclude group: 'org.json', module: 'json'
+  def jwt_version = '0.11.2' // https://github.com/jwtk/jjwt/releases
+  api 'io.jsonwebtoken:jjwt-api:$jwt_version'
+  runtimeOnly 'io.jsonwebtoken:jjwt-impl:$jwt_version' 
+  runtimeOnly('io.jsonwebtoken:jjwt-orgjson:$jwt_version') {
+    exclude group: 'org.json', module: 'json' //provided by Android natively
   }
 }
 


### PR DESCRIPTION
Related to #285 - when extracting the version I accidentally dropped the impl dependency

Where is the brown paper bag over head emoji?

This is the key line: https://github.com/notifee/react-native-notifee/compare/master...@mikehardy/fix-jwt-dependency?quick_pull=1#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aR81

This is the upstream install documentation for reference https://github.com/jwtk/jjwt#dependencies