### PR TITLE
Add <rootDir> to relative path in jest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In your Jest config file, add an entry to the `setupFilesAfterEnv` array, perhap
 module.exports = {
   // ... other directives
   setupFilesAfterEnv: [
-    'node_modules/@notifee/react-native/jest-mock.js'
+    './node_modules/@notifee/react-native/jest-mock.js'
   ],
   // ... other directives
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In your Jest config file, add an entry to the `setupFilesAfterEnv` array, perhap
 module.exports = {
   // ... other directives
   setupFilesAfterEnv: [
-    './node_modules/@notifee/react-native/jest-mock.js'
+    '<rootDir>/node_modules/@notifee/react-native/jest-mock.js'
   ],
   // ... other directives
 }


### PR DESCRIPTION
Jest seems to expect this as without the leading `./` it leads to the following error

```
● Validation Error:

  Module node_modules/@notifee/react-native/jest-mock.js in the setupFilesAfterEnv option was not found.
         <rootDir> is: <project root>

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```