### PR TITLE
Fix path to jest-mock in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In your Jest config file, add an entry to the `setupFilesAfterEnv` array, perhap
 module.exports = {
   // ... other directives
   setupFilesAfterEnv: [
-    'node_modules/@notifee/react-native/jest-mock.js'
+    '<rootDir>/node_modules/@notifee/react-native/jest-mock.js'
   ],
   // ... other directives
 }


### PR DESCRIPTION
It should either be `<rootDir>/node_modules` or `./node_modules`, but not `node_modules`.