### PR TITLE
feat(android): support alarm manager for trigger notifications

### DIFF
--- a/example/src/utils/triggers.ts
+++ b/example/src/utils/triggers.ts
@@ -3,10 +3,13 @@ import {
   TimestampTrigger,
   IntervalTrigger,
   TimeUnit,
+  RepeatFrequency,
 } from '@notifee/react-native';
 
 type TriggersItems = {
   timestamp: () => TimestampTrigger;
+  timestampWithAlarmManager: () => TimestampTrigger;
+  timestampWithAlarmManagerRepeating: () => TimestampTrigger;
   interval: () => IntervalTrigger;
 };
 
@@ -24,6 +27,21 @@ export const triggers: TriggersItems = {
   timestamp: () => ({
     timestamp: getTimestamp(),
     type: TriggerType.TIMESTAMP,
+  }),
+  timestampWithAlarmManager: () => ({
+    timestamp: getTimestamp(),
+    type: TriggerType.TIMESTAMP,
+    alarmManager: {
+      allowWhileIdle: true,
+    },
+  }),
+  timestampWithAlarmManagerRepeating: () => ({
+    timestamp: getTimestamp(),
+    type: TriggerType.TIMESTAMP,
+    repeatFrequency: RepeatFrequency.HOURLY,
+    alarmManager: {
+      allowWhileIdle: true,
+    },
   }),
   interval: () => ({
     timeUnit: TimeUnit.SECONDS,

--- a/src/types/Trigger.ts
+++ b/src/types/Trigger.ts
@@ -23,6 +23,12 @@ export interface TimestampTrigger {
    *  if set to `RepeatFrequency.WEEKLY`, the notification will repeat every week from the timestamp specified.
    */
   repeatFrequency?: RepeatFrequency;
+
+  alarmManager?: boolean | TimestampTriggerAlarmManager | undefined;
+}
+
+export interface TimestampTriggerAlarmManager {
+  allowWhileIdle?: boolean;
 }
 
 /**

--- a/src/validators/validateTrigger.ts
+++ b/src/validators/validateTrigger.ts
@@ -2,7 +2,14 @@
  * Copyright (c) 2016-present Invertase Limited
  */
 
-import { objectHasProperty, isNumber, isObject, isValidEnum } from '../utils';
+import {
+  objectHasProperty,
+  isNumber,
+  isObject,
+  isValidEnum,
+  isUndefined,
+  isBoolean,
+} from '../utils';
 import {
   Trigger,
   TimeUnit,
@@ -10,6 +17,7 @@ import {
   TimestampTrigger,
   IntervalTrigger,
   TriggerType,
+  TimestampTriggerAlarmManager,
 } from '../types/Trigger';
 
 const MINIMUM_INTERVAL = 15;
@@ -59,11 +67,42 @@ function validateTimestampTrigger(trigger: TimestampTrigger): TimestampTrigger {
     repeatFrequency: -1,
   };
 
-  if (objectHasProperty(trigger, 'repeatFrequency')) {
+  if (objectHasProperty(trigger, 'repeatFrequency') && !isUndefined(trigger.repeatFrequency)) {
     if (!isValidEnum(trigger.repeatFrequency, RepeatFrequency)) {
       throw new Error("'trigger.repeatFrequency' expected a RepeatFrequency value.");
     }
+
     out.repeatFrequency = trigger.repeatFrequency;
+  }
+
+  if (objectHasProperty(trigger, 'alarmManager') && !isUndefined(trigger.alarmManager)) {
+    if (isBoolean(trigger.alarmManager)) {
+      if (trigger.alarmManager) {
+        out.alarmManager = validateTimestampAlarmManager();
+      }
+    } else {
+      try {
+        out.alarmManager = validateTimestampAlarmManager(trigger.alarmManager);
+      } catch (e) {
+        throw new Error(`'trigger.alarmManager' ${e.message}.`);
+      }
+    }
+  }
+
+  return out;
+}
+
+function validateTimestampAlarmManager(
+  alarmManager?: TimestampTriggerAlarmManager,
+): TimestampTriggerAlarmManager {
+  const out: TimestampTriggerAlarmManager = {
+    allowWhileIdle: false,
+  };
+  if (!alarmManager) {
+    return out;
+  }
+  if (isBoolean(alarmManager.allowWhileIdle) && alarmManager.allowWhileIdle) {
+    out.allowWhileIdle = true;
   }
 
   return out;
@@ -80,7 +119,7 @@ function validateIntervalTrigger(trigger: IntervalTrigger): IntervalTrigger {
     timeUnit: TimeUnit.SECONDS,
   };
 
-  if (objectHasProperty(trigger, 'timeUnit')) {
+  if (objectHasProperty(trigger, 'timeUnit') && !isUndefined(trigger.timeUnit)) {
     if (!isValidEnum(trigger.timeUnit, TimeUnit)) {
       throw new Error("'trigger.timeUnit' expected a TimeUnit value.");
     }


### PR DESCRIPTION
Alpha release published 1.9.0-alpha.0

New Timestamp Trigger API:
```
{
   ...
  alarmManager: true | {
     allowWhileIdle: true
  }
}
```


E.G. (example [here](https://github.com/notifee/react-native-notifee/blob/bb70c8f52561623d264c282b523c9d58d766b498/example/src/utils/triggers.ts#L31)):

```
{
   timestamp: date,
   type: TriggerType.TIMESTAMP,
   alarmManager: {
     allowWhileIdle: true
   }
 }

```
