### PR TITLE
feat(android, sound): expose raw soundURI on android

### DIFF
--- a/src/types/NotificationAndroid.ts
+++ b/src/types/NotificationAndroid.ts
@@ -899,6 +899,13 @@ export interface AndroidChannel {
    * This setting cannot be overridden once the channel is created.
    */
   sound?: string;
+
+  /**
+   * The URI of the notification sound associated with the channel, if any.
+   *
+   * This is a read-only value, and is under user control after the channel is created
+   */
+  soundURI?: string;
 }
 
 /**


### PR DESCRIPTION

Related to #341 - this exposes the raw sound URI, and was used in testing on the related fix

For consideration: it may be useful to scan the NotificationChannelCompat API and incorporate all the new APIs for exposure but I fear scope creep / delay vs the necessary fix for #341

An easy+quick compromise might be to at least expose them all but mark them as read-only pending future support for setting them?

set of things not exposed includes information about conversations, whether user has customized a few items, and audio attributes (which may have been user-altered on the channel post-creation)