### PR TITLE
Remove @platform tags from docs which state `Trigger` is iOS specific

### DIFF
--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -139,8 +139,6 @@ export interface TriggerNotification {
 
   /**
    * The trigger that is used to schedule the notification
-   *
-   * @platform iOS
    */
   trigger: Trigger;
 }


### PR DESCRIPTION
...since it now works on Android too.

I _was_ going to remove it from DisplayedNotification too (https://github.com/notifee/react-native-notifee/blob/master/src/types/Notification.ts#L126) but, from briefly testing it, it seems like you don't get the `trigger` property on Android when calling `getDisplayedNotifications()`. Is this a platform limitation on the Android side or an omission in Notifee and it _should_ be present on both?