### PR TITLE
fix(android): add react-native 0.65 compatibility event emitter stubs

### DIFF
--- a/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -317,6 +317,16 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule {
     NotifeeReactUtils.hideNotificationDrawer();
   }
 
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
   @NonNull
   @Override
   public String getName() {


### PR DESCRIPTION

Been working through this in a few modules as I test the react-native 0.65 upgrade in a work project in order to fuzz-bust all the libraries

Here's the same in react-native-firebase https://github.com/invertase/react-native-firebase/pull/5616/files#diff-c887076b0c80d540aed1bfbb472cc8f20516634e8e72d53014c65d690bba4fb1

Also did it in netinfo and device-info modules - all seems to be working fine after being released a couple days.

I have this patch already test-integrated in my project via patch-package